### PR TITLE
remove unused dependency

### DIFF
--- a/communications/ff_hw_msgs/CMakeLists.txt
+++ b/communications/ff_hw_msgs/CMakeLists.txt
@@ -19,7 +19,6 @@ project(ff_hw_msgs)
 
 find_package(catkin2 REQUIRED COMPONENTS
   message_generation
-  roscpp
   std_msgs
   sensor_msgs
 )

--- a/communications/ff_hw_msgs/package.xml
+++ b/communications/ff_hw_msgs/package.xml
@@ -16,10 +16,8 @@
   </maintainer>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>ros_cpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <run_depend>ros_cpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <export></export>


### PR DESCRIPTION
This was causing build errors when I was trying to build only the *msgs packages.
roscpp isn't needed if you are only compiling messages. See [std_msgs](https://github.com/ros/std_msgs/blob/kinetic-devel/package.xml). Besides, ros_cpp is incorrect.

